### PR TITLE
Create .ssh directory in the home folder of Mac if its not present

### DIFF
--- a/mac/provision-devbox.sh
+++ b/mac/provision-devbox.sh
@@ -38,7 +38,7 @@ if grep $VM_NAME ~/.ssh/config > /dev/null;
 then 
     log "SSH already enabled";
 else
-    mkdir -p 700 ~/.ssh
+    mkdir -m 700 -p ~/.ssh
     echo "" >> ~/.ssh/config;
     echo "Include ${LIMA_HOME:-$HOME/.lima}/$VM_NAME/ssh.config" >> ~/.ssh/config;
 fi

--- a/mac/provision-devbox.sh
+++ b/mac/provision-devbox.sh
@@ -34,11 +34,11 @@ else
 fi
 
 log "Enable ssh to lima vm"
-if [ ! -d ~/.ssh ]; then mkdir -m 700 ~/.ssh; fi
 if grep $VM_NAME ~/.ssh/config > /dev/null; 
 then 
     log "SSH already enabled";
 else
+    mkdir -p 700 ~/.ssh
     echo "" >> ~/.ssh/config;
     echo "Include ${LIMA_HOME:-$HOME/.lima}/$VM_NAME/ssh.config" >> ~/.ssh/config;
 fi

--- a/mac/provision-devbox.sh
+++ b/mac/provision-devbox.sh
@@ -34,6 +34,7 @@ else
 fi
 
 log "Enable ssh to lima vm"
+if [ ! -d ~/.ssh ]; then mkdir -m 700 ~/.ssh; fi
 if grep $VM_NAME ~/.ssh/config > /dev/null; 
 then 
     log "SSH already enabled";


### PR DESCRIPTION
Encountered the below error on my fresh MAC in which ~/.ssh was not setup before.

<img width="748" alt="Screenshot 2025-01-20 at 1 25 54 PM" src="https://github.com/user-attachments/assets/68a6c1fa-b91f-4db7-88e0-1c60dead5a8d" />

A conditional check to create .ssh directory is added